### PR TITLE
use UTF-8 output to make STDOUT parseable 2020-08-20-11.07

### DIFF
--- a/core/scanner.py
+++ b/core/scanner.py
@@ -10,6 +10,8 @@ from terminaltables import AsciiTable, DoubleTable, SingleTable
 from colorama import Fore, Back, Style
 import shutil
 from . import report
+sys.stdout.reconfigure(encoding='utf-8')
+utf8stdout = open(1, 'w', encoding='utf-8', closefd=False) # fd 1 is stdout
 
 
 CODE_VULNERABILITIES = [
@@ -28,14 +30,14 @@ def scan(args):
 
     # Plugin repository URL
     if args.path[:7] in ['https:/', 'http://'] and args.path[-4:] != ".zip":
-        print(Fore.RED + '[ * ]' + Fore.RESET + " Downloading plugin from: " + args.path)
+        print(Fore.RED + '[ * ]' + Fore.RESET + " Downloading plugin from: " + args.path ,file=utf8stdout)
         download_url = scrape_download_url(args.path)
         download_plugin(download_url)
         args.path = ".temp/"
 
     # Plugin ZIP download URL
     if args.path[:7] in ['https:/', 'http://'] and args.path[-4:] == ".zip":
-        print(Fore.RED + '[ * ]' + Fore.RESET + " Downloading ZIP plugin from: " + args.path)
+        print(Fore.RED + '[ * ]' + Fore.RESET + " Downloading ZIP plugin from: " + args.path, file=utf8stdout)
         download_plugin(args.path)
         args.path = ".temp/"
 
@@ -49,31 +51,31 @@ def scan(args):
         for file in f:
             if '.php' in file:
                 count_files = count_files + 1
-                print('Checked files: ' + str(count_files), end="\r")
+                print('Checked files: ' + str(count_files), end="\r", file=utf8stdout)
                 check_file(file, r, modules)
 
     # Print registered admin actions
     table_instance = SingleTable(passive_check.ADMIN_ACTIONS_DATA, Fore.GREEN + " Admin Actions " + Style.RESET_ALL)
     table_instance.justify_columns[2] = 'left'
-    print(table_instance.table)
+    print(table_instance.table, file=utf8stdout)
     print()
 
     # Print registered ajax hooks
     table_instance = SingleTable(passive_check.AJAX_HOOKS_DATA, Fore.GREEN + " Registered Hooks " + Style.RESET_ALL)
     table_instance.justify_columns[2] = 'left'
-    print(table_instance.table)
+    print(table_instance.table, file=utf8stdout)
     print()
 
     # Print admin init functions
     table_instance = SingleTable(passive_check.ADMIN_INIT_DATA, Fore.GREEN + " Admin Init " + Style.RESET_ALL)
     table_instance.justify_columns[2] = 'left'
-    print(table_instance.table)
+    print(table_instance.table, file=utf8stdout)
     print()
 
     # Print vulnerabilities
     table_instance = SingleTable(CODE_VULNERABILITIES, Fore.RED + " Found Vulnerabilities " + Style.RESET_ALL)
     table_instance.justify_columns[2] = 'left'
-    print(table_instance.table)
+    print(table_instance.table, file=utf8stdout)
     print()
 
     # Save report if requested

--- a/core/scanner.py
+++ b/core/scanner.py
@@ -10,7 +10,10 @@ from terminaltables import AsciiTable, DoubleTable, SingleTable
 from colorama import Fore, Back, Style
 import shutil
 from . import report
-sys.stdout.reconfigure(encoding='utf-8')
+
+# if using stdout , utf-8 could be set for all
+# import sys
+# sys.stdout.reconfigure(encoding='utf-8')
 utf8stdout = open(1, 'w', encoding='utf-8', closefd=False) # fd 1 is stdout
 
 


### PR DESCRIPTION
after trying `python3 wpbullet .... 2>&1 | iconv` and many other variants , it turned out that either a ugly script to rectify unprintable characters or tricking python into utf8 was necessary to feed text2html ..

After lots of googling , it turned out that python3 has to be told to use utf-8 by default  ( https://stackoverflow.com/Questions/4374455/how-to-set-sys-stdout-encoding-in-python-3 ) 

This fix needs at least pyton3.6 or the `sys.stdout.reconfigure(encoding='utf-8')` line needs to be removed.

Regards